### PR TITLE
BUG FIX: v1,v2-negative exp, underflow, and overflow handling.

### DIFF
--- a/golden/addmult_crosscheck.py
+++ b/golden/addmult_crosscheck.py
@@ -67,7 +67,7 @@ try:
                 try:
                     a_v1 = v1.bfloat(str(a[0]),str(a[1:9]),str(a[9:]))
                     b_v1 = v1.bfloat(str(b[0]),str(b[1:9]),str(b[9:]))
-                    c_v1 = v1.bfloat_mult(a_v1,b_v1)
+                    c_v1 = v1.bfloat_mult(a_v1,b_v1).display_bin()
 
                     if(not quiet):
                         print("Version 1: ",c_v1)

--- a/golden/addmult_v1.py
+++ b/golden/addmult_v1.py
@@ -68,11 +68,15 @@ def bfloat_mult(a, b):
     o_man = [int(x) for x in bin(o_man_mag)[2:]]
     whole = len(o_man) - 14
     o_exp_mag = a_exp + b_exp + (whole - 1) + 127
+    if o_exp_mag < 0:
+        o_exp_mag = o_exp_mag + 127
     o_exp = [int(x) for x in bin(o_exp_mag)[2:]]
     if len(o_exp) < 8:
-        diff = 8 - len(o_expo)
+        diff = 8 - len(o_exp)
         extra = [int(x)*0 for x in range(0, diff)]
         o_exp = extra + o_exp
+    elif len(o_exp) > 8:
+        o_exp = [int(x)*0 for x in range (0, 8)]
     if len(o_man) > 8:
         o_man = o_man[1:8]
     else:

--- a/golden/addmult_v2.py
+++ b/golden/addmult_v2.py
@@ -1,5 +1,4 @@
 #Python program for bfloat16, a truncated mantissa version of IEEE 754 float32
-#
 
 class bfloat:
 	def __init__(self, a):
@@ -45,11 +44,10 @@ class bfloat:
 			return ((-1)**int(self.sign) * 2**exp_mag * (man_mag + 1))
 	#end mag
 #end class
-
-
 #----------------------------------------------------------------------------------------------
+
 #add_bin: compressor adder the multiplier's partial sums
-#	inputs: (a, b) unsigned binary strings with same lengths
+#	inputs: (a, b) unsigned binary strings 
 #	output: (Cin, add_sum) single binary string
 def add_bin(a, b):
 	Cin = 0
@@ -65,19 +63,14 @@ def add_bin(a, b):
 		for i in range(len(b) - len(a)):
 			a = '0' + a
 
-	#A ripple carry adder; a and b should be the same lengths.
+	#A ripple carry adder
 	for i in range(len(a)-1, -1, -1):
-		#a1, b1 to make the code look cleaner
 		a1 = int(a[i])
 		b1 = int(b[i])
-		#Full-adder expressions. The Cout from previous stage becomes Cin of the new stage.
 		add_sum = str(a1^ b1 ^ Cin) + add_sum
 		Cin = (a1 & b1) ^ (Cin & (a1 ^ b1))
 
-	#returns the the sum and the carry-out
 	return str(Cin) + add_sum
-
-
 #----------------------------------------------------------------------------------------------
 
 #mult_bfloat16:
@@ -103,37 +96,30 @@ def mult_bfloat16(a, b):
 	#Substrate the bias and add the exponents.
 	o_exp = (int(a.exp,2) - 127)  + (int(b.exp,2) - 127)
 
-	#Add the implicit 1 in front of mantissa. See Bfloat16 format.
+	#Calculate the mantissa
 	a_man = ('1' + a.man)
 	b_man=  ('1' + b.man)
-
-	#Calculate the partial sum of the mantissa
 	o_man = int(a_man,2) * int(b_man,2)
 	o_man = bin(o_man)[2:]
 
 	#Normalize output mantissa, adding the extra exponents, and add the bias
 	o_exp += len(o_man) - (14) - (1)
 	o_exp += 127
+
+	if o_exp < 0: 
+		o_exp += 127
+	if o_exp > 255:  #if o_exp > '1111_1111'
+		o_exp = 255
+
 	o_exp = bin(o_exp)[2:].rjust(8, '0')
-
-	#Truncate partial sum
 	o_man = o_man[1:8].ljust(7, '0')
-
-	#concentate sign,exponent,mantissa into one string
-	mult_out = bfloat(o_sign + o_exp + o_man)
-	return mult_out
-
-#---------------------------------------------------------------------------------------------
-
+	
+	return bfloat(o_sign + o_exp + o_man)
+# end mult_bfloat()----------------------------------------------------------------------------
 
 # a = bfloat('0000000000000001')
 # b = bfloat('0000000000000001')
-# c = bfloat('0000000000000000')  # c = 'zero'
-# d = bfloat('1111111110000000')  # d = '-inf'
-#
-# #result should be 11000010011100
-# mult_bfloat16(a , b).bin_parsed()
-# #
-# # print(mult_bfloat16(a , c).bin_parsed())
-# # print(mult_bfloat16(a , d).bin_parsed())
-# # print(mult_bfloat16(c , d).bin_parsed())
+
+# print(mult_bfloat16(a , b).bin_parsed())
+
+


### PR DESCRIPTION
Added to cases to handle for when the product exponent is negative and when the exponent is greater than 255 (0b1111_1111).

Fixed typo in addmult_v1.py: `o_expo` to `o_exp`. Cleaned up the code in addmult_v2.py. Minor edit to addmult_crosscheck.py to display the bin of `c_v1`
