### PR TITLE
Testbench/golden: Denormalize number, v2 API changes, Bug Fixes

### DIFF
--- a/golden/addmult_crosscheck.py
+++ b/golden/addmult_crosscheck.py
@@ -80,12 +80,12 @@ try:
             #version 2
             if (version == 0 or version == 2):
                 try:
-                    a_v2 = v2.bfloat(a)
-                    b_v2 = v2.bfloat(b)
-                    c_v2 = v2.mult_bfloat16(a_v2, b_v2).bin_parsed()
+                    a_v2 = v2.bfloat(str(a[0]),str(a[1:9]),str(a[9:]))
+                    b_v2 = v2.bfloat(str(b[0]),str(b[1:9]),str(b[9:]))
+                    c_v2 = v2.bfloat_mult(a_v2,b_v2).display_bin()
 
                     if(not quiet):
-                        print("Version 2: ",c_v2)
+                        print("Version 2: ", c_v2)
                         print("="*15)
                 except Exception as e:
                     if (strict):

--- a/golden/addmult_v2.py
+++ b/golden/addmult_v2.py
@@ -1,13 +1,13 @@
 #Python program for bfloat16, a truncated mantissa version of IEEE 754 float32
 
 class bfloat:
-	def __init__(self, a):
-		if len(a) != 16:
+	def __init__(self, s, e, m):
+		if len(s) + len(e) + len(m) != 16:
 			print("Argument isn't 16bits")
 		else:
-			self.sign = a[0]
-			self.exp = a[1:9]
-			self.man  = a[9:]
+			self.sign = s
+			self.exp = e
+			self.man  = m
 			self.value = ''
 
 			if self.exp == '11111111':
@@ -16,67 +16,39 @@ class bfloat:
 				else:
 					self.value = 'NaN'
 
-			if int(a[1:],2) == 0:
+			if int(e,2) + int(m,2) == 0:
 				self.value = 'zero'
 	#end __init___
 
-	def bin_parsed(self):
+	def display_bin(self):
 		return self.sign, self.exp, self.man
 	#end bin_parsed
 
-	def bin(self):
-		return self.sign + self.exp + self.man
-	#end bin
-
-	def mag(self):
-		exp_mag = int(self.exp,2) - 127
+	def display_dec(self):
+		exp_mag = int(self.exp,2)
 		start = -1
 		man_mag = 0.0
 		for m in self.man:
 			man_mag = man_mag + int(m) * 2 ** (start)
 			start = start - 1
 
-		if self.value == 'zero':
-			return 0.0
+		if self.exp == '00000000':
+			if self.man == '0000000':
+				return 0.0
+			else: 
+				return ((-1)**int(self.sign) * 2**(exp_mag - 126) * (man_mag)) 
 		elif self.value == 'inf':
 			return float('Inf')
 		else:
-			return ((-1)**int(self.sign) * 2**exp_mag * (man_mag + 1))
+			return ((-1)**int(self.sign) * 2**(exp_mag - 127) * (man_mag + 1))
 	#end mag
 #end class
 #----------------------------------------------------------------------------------------------
 
-#add_bin: compressor adder the multiplier's partial sums
-#	inputs: (a, b) unsigned binary strings 
-#	output: (Cin, add_sum) single binary string
-def add_bin(a, b):
-	Cin = 0
-	add_sum = ''
-
-	#sign extension
-	if(len(a) > len(b)):
-		#sign extend b
-		for i in range(len(a) - len(b)):
-			b = '0' + b
-	elif(len(b) > len(a)):
-		#sign extend a
-		for i in range(len(b) - len(a)):
-			a = '0' + a
-
-	#A ripple carry adder
-	for i in range(len(a)-1, -1, -1):
-		a1 = int(a[i])
-		b1 = int(b[i])
-		add_sum = str(a1^ b1 ^ Cin) + add_sum
-		Cin = (a1 & b1) ^ (Cin & (a1 ^ b1))
-
-	return str(Cin) + add_sum
-#----------------------------------------------------------------------------------------------
-
 #mult_bfloat16:
-#	input: (a, b) two 16bit binary string in Bfloat16 format, where a[0], b[0] are the MSBs
-#	output: (mult_out) 16bit binary string in Bfloat16 format, where mult_out[0] is the
-def mult_bfloat16(a, b):
+#   input: (a, b) two 16bit binary string in Bfloat16 format, where a[0], b[0] are the MSBs
+#   output: (mult_out) 16bit binary string in Bfloat16 format, where mult_out[0] is the
+def bfloat_mult(a, b):
 
 	#output sign
 	o_sign = int(a.sign) ^ int(b.sign)
@@ -85,20 +57,29 @@ def mult_bfloat16(a, b):
 	#Edge cases for +-Inf, +-NaN, +-Zero
 	#Order of precedence: NaN -> Zero -> Inf
 	if a.value == 'NaN' or b.value == 'NaN':
-		return bfloat(o_sign + '111111110000001')
+		return bfloat(o_sign, '11111111', '0000001')
 
 	if a.value == 'zero' or b.value == 'zero':
-		return bfloat(o_sign + '000000000000000')
+		return bfloat(o_sign, '00000000', '0000000')
 
 	if a.value == 'inf' or b.value == 'inf':
-		return bfloat(o_sign + '111111110000000')
+		return bfloat(o_sign, '11111111', '0000000')
 
 	#Substrate the bias and add the exponents.
-	o_exp = (int(a.exp,2) - 127)  + (int(b.exp,2) - 127)
+	if int(a.exp,2) > 0:
+		o_exp = (int(a.exp,2) - 127)  + (int(b.exp,2) - 127)
+	else:
+		o_exp = (int(a.exp,2) - 126)  + (int(b.exp,2) - 126)
 
-	#Calculate the mantissa
-	a_man = ('1' + a.man)
-	b_man=  ('1' + b.man)
+
+	#normalize
+	a_man = a.man
+	b_man = a.man
+	if int(a.exp,2) > 0:
+	   a_man = ('1' + a.man)
+	if int(b.exp,2) > 0:
+	   b_man=  ('1' + b.man)
+
 	o_man = int(a_man,2) * int(b_man,2)
 	o_man = bin(o_man)[2:]
 
@@ -107,19 +88,21 @@ def mult_bfloat16(a, b):
 	o_exp += 127
 
 	if o_exp < 0: 
-		o_exp += 127
+		o_exp = 0
+
 	if o_exp > 255:  #if o_exp > '1111_1111'
 		o_exp = 255
 
 	o_exp = bin(o_exp)[2:].rjust(8, '0')
 	o_man = o_man[1:8].ljust(7, '0')
 	
-	return bfloat(o_sign + o_exp + o_man)
+	return bfloat(o_sign, o_exp, o_man)
 # end mult_bfloat()----------------------------------------------------------------------------
 
-# a = bfloat('0000000000000001')
-# b = bfloat('0000000000000001')
+a = bfloat('0', '00000001', '1000100')
+print(a.display_dec())
 
-# print(mult_bfloat16(a , b).bin_parsed())
+print(mult_bfloat16(a, a).display_dec())
+print(a.display_dec() * a.display_dec())
 
 

--- a/golden/addmult_v2.py
+++ b/golden/addmult_v2.py
@@ -36,11 +36,13 @@ class bfloat:
 			if self.man == '0000000':
 				return 0.0
 			else: 
-				return ((-1)**int(self.sign) * 2**(exp_mag - 126) * (man_mag)) 
+				out = ((-1)**int(self.sign) * 2**(exp_mag - 126) * (man_mag)) 
+				return (out)
 		elif self.value == 'inf':
 			return float('Inf')
 		else:
-			return ((-1)**int(self.sign) * 2**(exp_mag - 127) * (man_mag + 1))
+			out = ((-1)**int(self.sign) * 2**(exp_mag - 127) * (man_mag + 1))
+			return (out)
 	#end mag
 #end class
 #----------------------------------------------------------------------------------------------
@@ -66,25 +68,33 @@ def bfloat_mult(a, b):
 		return bfloat(o_sign, '11111111', '0000000')
 
 	#Substrate the bias and add the exponents.
-	
 	o_exp = (int(a.exp,2) - 127)  + (int(b.exp,2) - 127)
 
 	#normalize
 	a_man = '1' + a.man
 	b_man = '1' + b.man
 
+	if a.exp == '00000000':
+		a_man = a.man
+	if b.exp == '00000000':
+		b_man = b.man
+
 	o_man = int(a_man,2) * int(b_man,2)
 	o_man = bin(o_man)[2:]
 
 	#Normalize output mantissa, adding the extra exponents, and add the bias
-	o_exp += len(o_man) - (14) - (1)
+	dec_len =(len(a_man) - 1) + (len(b_man) - 1)
 	o_exp += 127
+	if len(o_man) <= dec_len + 1 and o_exp == 0:
+		o_man = o_man.rjust(15,'0')
+	else:
+		o_exp += len(o_man) - (dec_len) - (1)
 
-	if o_exp < 0: 
-		o_exp = 0
+	if o_exp <= 0: 
+		return bfloat(o_sign, '0'*8, '0'*7)
 
-	if o_exp > 255:  #if o_exp > '1111_1111'
-		o_exp = 255
+	if o_exp >= 255:  #if o_exp > '1111_1111'
+		return bfloat(o_sign, '1'*8, '0'*7)
 
 	o_exp = bin(o_exp)[2:].rjust(8, '0')
 	o_man = o_man[1:8].ljust(7, '0')
@@ -92,10 +102,10 @@ def bfloat_mult(a, b):
 	return bfloat(o_sign, o_exp, o_man)
 # end mult_bfloat()----------------------------------------------------------------------------
 
-a = bfloat('0', '00000000', '1111000')
-b = bfloat('0', '01111111', '0000110')
-print(a.display_dec())
-print(b.display_dec())
-print(bfloat_mult(a, b).display_dec())
-print(a.display_dec() * b.display_dec())
+# a = bfloat('0', '10010111', '0100011')
+# b = bfloat('0', '11110101', '0110010')
+# print(a.display_dec())
+# print(b.display_dec())
+# print(bfloat_mult(a, b).display_dec())
+# print(a.display_dec() * b.display_dec())
 

--- a/golden/addmult_v2.py
+++ b/golden/addmult_v2.py
@@ -66,19 +66,12 @@ def bfloat_mult(a, b):
 		return bfloat(o_sign, '11111111', '0000000')
 
 	#Substrate the bias and add the exponents.
-	if int(a.exp,2) > 0:
-		o_exp = (int(a.exp,2) - 127)  + (int(b.exp,2) - 127)
-	else:
-		o_exp = (int(a.exp,2) - 126)  + (int(b.exp,2) - 126)
-
+	
+	o_exp = (int(a.exp,2) - 127)  + (int(b.exp,2) - 127)
 
 	#normalize
-	a_man = a.man
-	b_man = a.man
-	if int(a.exp,2) > 0:
-	   a_man = ('1' + a.man)
-	if int(b.exp,2) > 0:
-	   b_man=  ('1' + b.man)
+	a_man = '1' + a.man
+	b_man = '1' + b.man
 
 	o_man = int(a_man,2) * int(b_man,2)
 	o_man = bin(o_man)[2:]
@@ -99,10 +92,10 @@ def bfloat_mult(a, b):
 	return bfloat(o_sign, o_exp, o_man)
 # end mult_bfloat()----------------------------------------------------------------------------
 
-a = bfloat('0', '00000001', '1000100')
+a = bfloat('0', '00000000', '1111000')
+b = bfloat('0', '01111111', '0000110')
 print(a.display_dec())
-
-print(mult_bfloat16(a, a).display_dec())
-print(a.display_dec() * a.display_dec())
-
+print(b.display_dec())
+print(bfloat_mult(a, b).display_dec())
+print(a.display_dec() * b.display_dec())
 


### PR DESCRIPTION
1. addmult_v2.py now follows the denormalize standard when the exponent is 0b0000_0000
2. Changed v2's API to match v1, and crosscheck is updated to correspond the new API
3. Bug fixes where v2 would not flush to zero or inf properly. 