### PR TITLE
PET: Addmult_v2.py update

### DIFF
--- a/golden/golden/basic_logic/addmult_v2.py
+++ b/golden/golden/basic_logic/addmult_v2.py
@@ -1,36 +1,49 @@
-#Python program for bfloat16, a truncated mantissa version of IEEE 754 float32
+#Python program for bfloat, a truncated mantissa version of IEEE 754 float32
 from numpy import float32
 from numpy import random
-
+import struct
+import sys
 
 class bfloat:
-	def __init__(self, s, e, m):
+	def __init__(self, s, e = '', m = ''):
 		if len(s) + len(e) + len(m) != 16:
 			print("Argument isn't 16bits:" , s, e, m)
 		else:
-			self.sign = s
-			self.exp = e
-			self.man  = m
+			#Unparsed string is provided 
+			if s and e == '' and m == '':
+				self.sign = s[0]
+				self.exp = s[1:9]
+				self.man = s[9:]
+			#Parse string is provided
+			else:
+				self.sign = s
+				self.exp = e
+				self.man  = m
+
 			self.value = ''
 
+			#TODO: add -inf, -NaN, -zero
 			if self.exp == '11111111':
 				if int(self.man,2) == 0:
 					self.value = 'inf'
 				else:
 					self.value = 'NaN'
 
-			if int(e,2) + int(m,2) == 0:
+			if int(self.exp ,2) + int(self.man ,2) == 0:
 				self.value = 'zero'
-	#end __init___
+	#end __init___() 
 
+	#display parsed binary representation
 	def display_bin(self):
 		return (self.sign, self.exp, self.man)
 	#end display_bin()
 	
+	#display unparsed binary represenation
 	def bin(self):
 		return self.sign + self.exp + self.man
 	#end bin()
 
+	#Display the decimal representation of bfloat
 	def display_dec(self):
 		exp_mag = int(self.exp,2)
 		start = -1
@@ -53,15 +66,37 @@ class bfloat:
 		else:
 			out = ((-1)**int(self.sign) * 2**(exp_mag - 127) * (man_mag + 1))
 			return (float32(out))
-	#end mag
-#end class
+
+	#Operator overloading
+	#Only works with self and b are both bfloat
+	def __add__(self, b):
+		return bfloat_add(self, b)
+	def __mul__(self, b):
+		return bfloat_mult(self, b)
+
+#----------------------------------------------------------------------------------------------	
+#end bfloat class
 #----------------------------------------------------------------------------------------------
 
+
 #Randomly generates a 16bit binary
-def rand16bin():
+def rand16():
 	a = random.randint(2, size = 16)
 	s = ''.join(str(i) for i in a)
 	return s
+#-----------------------------------------------------------------------------------------------
+
+#Converters float32 to bfloat
+def f2bfloat(num):
+    packed = struct.pack('!f', num)
+    integers = [c for c in packed]
+    binaries = [bin(i) for i in integers]
+    stripped_binaries = [s.replace('0b', '') for s in binaries]
+    padded = [s.rjust(8, '0') for s in stripped_binaries]
+    
+    return bfloat(''.join(padded)[:16])
+
+
 #-----------------------------------------------------------------------------------------------
 
 #parsers single binary string into its sign, exp, and man components
@@ -71,8 +106,8 @@ def bin_parser(a):
 #-----------------------------------------------------------------------------------------------
 
 #mult_bfloat16:
-#   input: (a, b) two 16bit binary string in Bfloat16 format, where a[0], b[0] are the MSBs
-#   output: (mult_out) 16bit binary string in Bfloat16 format, where mult_out[0] is the
+#   input: (a, b) two 16bit binary string in Bfloat format, where a[0], b[0] are the MSBs
+#   output: (mult_out) 16bit binary string in Bfloat format, where mult_out[0] is the
 def bfloat_mult(a, b):
 
 	#output sign
@@ -205,7 +240,6 @@ def bfloat_add(a, b):
         return bfloat(out_sign, '0'*8, out_man[0:7])
 
     # print(out_exp)
-    #TODO: Bugs with negative exponent 
     out_exp = bin(out_exp)[2:]
     if len(out_exp) < 8:
         exp_fill = 8 - len(out_exp)
@@ -218,19 +252,25 @@ def bfloat_add(a, b):
     
     # print(out_sign, out_exp, out_man)
     return bfloat(out_sign, out_exp, (out_man)[1:8])
+#End bfloat_add() -------------------------------------------------
 
-###############################################################
-# s1,e1,m1 = bin_parser('0011101011111011')
-# s2,e2,m2 = bin_parser('1011101100000000')
-# a = bfloat(s1,e1,m1)
-# b = bfloat(s2,e2,m2)
-# sum = bfloat_add(a,b)
-# sum32 = a.display_dec() + b.display_dec() 
+#For debugging
+if __name__ == '__main__':
+	# s1,e1,m1 = bin_parser('0011101011111011')
+	# s2,e2,m2 = bin_parser('1011101100000000')
+	# a = bfloat(s1,e1,m1)
+	# b = bfloat(s2,e2,m2)
+	# sum = bfloat_add(a,b)
+	# sum32 = a.display_dec() + b.display_dec() 
 
-# print("binary a: ", a.sign, a.exp, a.man)
-# print("binary b: ", b.sign, b.exp, b.man)
-# print("decimal a: ", a.display_dec())
-# print("decimal b: ", b.display_dec())
-# print("sum32 : ", sum32)
-# print("sum   : ", sum.display_dec())
-# print("sum bin: ", sum.display_bin())
+	# print("binary a: ", a.sign, a.exp, a.man)
+	# print("binary b: ", b.sign, b.exp, b.man)
+	# print("decimal a: ", a.display_dec())
+	# print("decimal b: ", b.display_dec())
+	# print("sum32 : ", sum32)
+	# print("sum   : ", sum.display_dec())
+	# print("sum bin: ", sum.display_bin())
+	
+	b = f2bfloat(54.1567)
+	print(b.display_dec())
+

--- a/golden/golden/layer/convolution.py
+++ b/golden/golden/layer/convolution.py
@@ -26,7 +26,7 @@ def zero_padding(input, input_d, padding):
 
     for i in range(padded_input_s):
         if (i < (padded_input_d * padding) + padding):
-            padded_input[i] = format('0')
+            padded_input[i] = format('0'*16)
         else:
             if (input_count < input_s):
                 if (row_count < input_d):
@@ -45,12 +45,13 @@ def zero_padding(input, input_d, padding):
     return padded_input
 
 def dotproduct_and_summation(input, input_d, filter, filter_d, filter_s, start):
-    sum = format('0')
+    sum = format('0'*16)
     count = 0
     offset = 0
 
     for i in range(filter_s):
-        sum = add(mult(input[start + offset], filter[i]),sum)
+        # sum = add(mult(input[start + offset], filter[i]),sum)
+        sum = (input[start+offset] * filter[i]) + sum
         if(count == filter_d - 1):
             count = 0
             offset += input_d - filter_d + 1


### PR DESCRIPTION
- added `f2bfloat()` converts float32 precision to bfloat precision (i.e. 54.1567 -> 54.0).
- overloaded `+` and `*` operators with `bfloat_add()` and `bfloat_mult`, respectively. Right, now, only works if LHS and RHS are both type `bfloat`